### PR TITLE
[Dev] Add `make` action for CI

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,19 @@
+name: C CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Make directories
+      run: mkdir -p objects
+    - name: make
+      run: make


### PR DESCRIPTION
Adds an action to build the repository using `make` for continous integration.